### PR TITLE
style: fixed header spacing responsively in gallery page

### DIFF
--- a/src/pages/Gallery/Gallery.jsx
+++ b/src/pages/Gallery/Gallery.jsx
@@ -163,7 +163,7 @@ export default function Gallery() {
     <PageTransition>
       <Heading
         text="Gallery"
-        className="text-center absolute top-0 left-0 right-0 mb-24"
+        className="text-center absolute top-0 left-0 right-0 mt-4 md:mt-8 lg:mt-12 mb-4 md:mb-8 lg:mb-12"
       />
       <div className="grid grid-cols-2 md:grid-cols-3 gap-4 m-[5%]">
         {images.map((image, index) => (


### PR DESCRIPTION
Fixed margin properties in Gallery page's header to fix inconsistent styling across different screen dimensions.
![image](https://github.com/user-attachments/assets/d1aa5b73-cec2-4378-bef7-e5465febbe67)
![image](https://github.com/user-attachments/assets/10cedd90-f628-4c94-81f5-66ac4a915198)
