### PR TITLE
fix: upgraded upload and download artifacts to v4 fixes #94

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Node
         uses: actions/setup-node@v3
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: production-files
           path: ./dist


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/ci.yaml` to use the latest versions of key actions for improved stability and compatibility.

Updates to GitHub Actions versions:

* Updated the `actions/checkout` action from version `v3` to `v4` in the `Checkout Code` step.
* Updated the `actions/download-artifact` action from version `v3` to `v4` in the `Download artifact` step.