### PR TITLE
Codex 94 deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
           path: ./dist
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.CI_CD_TOKEN }}
           publish_dir: ./dist


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the `peaceiris/actions-gh-pages` action.

Version update:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL52-R52): Updated the `peaceiris/actions-gh-pages` action from version `v3` to `v4` in the "Deploy to GitHub Pages" step.